### PR TITLE
Use []DataObject in SplitInBatches

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,7 +34,11 @@ func main() {
 	docs := load(jsonFile)
 	fmt.Printf("Documents to classify: %d\n", len(docs))
 
-	batches := monkeylearn.SplitInBatches(docs, *batchSize)
+	var dataObjects = []monkeylearn.DataObject{}
+	for _, doc := range docs {
+		dataObjects = append(dataObjects, monkeylearn.DataObject{Text: doc, ExternalID: nil})
+	}
+	batches := monkeylearn.SplitInBatches(dataObjects, *batchSize)
 	fmt.Printf("Batch size: %d\n", *batchSize)
 	fmt.Printf("Number of batches: %d\n", len(batches))
 

--- a/pkg/monkeylearn/batch.go
+++ b/pkg/monkeylearn/batch.go
@@ -53,7 +53,7 @@ func (b Batch) Extract(model string, client *Client) ([]Result, error) {
 // SplitInBatches takes a list of documents and the expected size of
 // each Batch and returns a list of Batches with batchSize elements
 // each.
-func SplitInBatches(docs []string, batchSize int) []*Batch {
+func SplitInBatches(docs []DataObject, batchSize int) []*Batch {
 	defer startTimer("Split in batches")()
 	batches := []*Batch{}
 	count := 0
@@ -63,7 +63,7 @@ func SplitInBatches(docs []string, batchSize int) []*Batch {
 			tmpbatch = NewBatch()
 		}
 		count++
-		tmpbatch.Add(DataObject{Text: doc})
+		tmpbatch.Add(doc)
 		if count % batchSize == 0 || count == len(docs) {
 			batches = append(batches, tmpbatch)
 		}


### PR DESCRIPTION
`DataObject` includes an `ExternalID` field that is carried through
the classification, but access to this field was not available if
`SplitInBatches` was used.

Expose the `DataObject` struct directly in the signature of
`SplitInBatches` so users have access to that field. They will need to
serialize their input into an array of `DataObjects` instead of an
array of `string`s.