### PR TITLE
Add contribution guidelines

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,12 @@
+This document lists all the authors that have contributed code or
+documentation to the project and are therefore mentioned in a
+commit. To be listed, they must have submitted their contribution in
+conformance with the rules and License of this project at the time of
+their submission.
+
+The list's format is Name, followed by email address used in the
+submission between '<>'. If more than an address has been used, they
+should be listed one after the other, with one author per
+line. Author's are sorted alphabetically by name.
+
+Miguel Bernabeu Diaz <miguel.bernabeu@devex.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+## Issue guidelines
+
+## Commit requirements
+
+Commits should have a summary and a body. The summary should be
+descriptive of the commit's intent, use active voice and start with a
+verb. It's length should not exceed 50 characters and must not exceed
+72 characters.
+
+The body can be as long as needed and explained the rationale behind
+the change, not describe the changes inside the commit themselves. It
+should provide all information needed to understand the commit in
+isolation.
+
+Commits should include a `Signed-off` entry to conform with the
+Developer Certificate of Origin, which effectively states the
+contribution is done in good faith under the current license of the
+project. The license terms can be reviewed in the [LICENSE](LICENSE)
+file in the repo, and the requirements of the DCO are in the
+[DCO](DCO) file in the repo.
+
+```
+Add an example commit
+
+This commit is done here to show what a typical message looks
+like. Here I describe the reasoning behind the change, which is to show
+what a commit should look like.
+
+Signed-off-by: Miguel Bernabeu <miguel.bernabeu@lobber.eu>
+```
+
+This line will be added by `git` automatically if you add the `-s` flag when creating a commit:
+```
+git commit -s
+```
+
+## Pull Request requirements

--- a/DCO
+++ b/DCO
@@ -1,0 +1,25 @@
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Unofficial MonkeyLearn API client in Go
+
+## Goal and scope
+
+## Usage
+
+## License
+
+This project is under the MIT license, as shown in the LICENSE
+file. Contributions are covered under the Developer Certificate of
+Origin (DCO) inspired by the Linux Kernel's DCO. You can find its
+terms in the [DCO](DCO) file in this repo and a description on how it
+affects contributions in the [Contributing](CONTRIBUTING.md) file.
+
+## Contact and issues
+
+Issues and Pull Requests are currently managed via
+[GitHub](github.com/miguelbernadi/monkeylearn-go).
+
+## Contributing
+
+Contributions are considered to be held under the MIT license as
+specified in the [LICENSE](LICENSE) file. All commits must show a
+Developer Certificate of Origin (DCO) as detailed in the
+[Contributing](CONTRIBUTING.md) file in the root of this repo.
+
+## Contributors
+
+Contributors to the project can be seen in the [AUTHORS](AUTHORS) file.


### PR DESCRIPTION
This commit introduces the DCO and explanations on how to contribute
to the project under the appropriate license, so it can be easily
opened up to wider contributions.

Signed-off-by: Miguel Bernabeu <miguel.bernabeu@devex.com>