### PR TITLE
Small fixes/improvements

### DIFF
--- a/pkg/monkeylearn/batch.go
+++ b/pkg/monkeylearn/batch.go
@@ -23,10 +23,10 @@ func NewBatch() *Batch {
 	return &Batch{}
 }
 
-// Add adds a document to an existing Batch, updates the referenced
-// document and returns it.
-func (b *Batch) Add(document DataObject) *Batch {
-	b.Data = append(b.Data, document)
+// Add adds a set document to an existing Batch, updates the
+// referenced document and returns it.
+func (b *Batch) Add(document ...DataObject) *Batch {
+	b.Data = append(b.Data, document...)
 	return b
 }
 

--- a/pkg/monkeylearn/client.go
+++ b/pkg/monkeylearn/client.go
@@ -93,7 +93,9 @@ func (r Result) Error() error {
 	return nil
 }
 
-func MargeResultList(lists ...[]Result) []Result {
+// MergeResultList returns a slice of Result resulting of merging a
+// series of Result slices
+func MergeResultList(lists ...[]Result) []Result {
 	dict := make(map[string]Result)
 
 	for _, list := range lists {

--- a/pkg/monkeylearn/client.go
+++ b/pkg/monkeylearn/client.go
@@ -143,7 +143,7 @@ type Extraction struct {
 func startTimer(name string) func() {
 	t := time.Now()
 	return func() {
-		d := time.Now().Sub(t)
+		d := time.Since(t)
 		log.Println(name, "took", d)
 	}
 }


### PR DESCRIPTION
These changes only affect Public API in the typo case, which was still unused
publicly.

**Fix typo in function name**
Also add documentation for the function.

**Fix staticcheck violation**
It's recommended to use time.Since instead of manually subtracting two
time objects.

**Make Batch.Add variadic**
It can now accept an indeterminate number of DataObject structs and
will do the operation on them all.