### PR TITLE
Introduce minimal testing

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,7 +42,7 @@ func main() {
 	fmt.Printf("Batch size: %d\n", *batchSize)
 	fmt.Printf("Number of batches: %d\n", len(batches))
 
-	client := monkeylearn.NewClient(*token)
+	client := monkeylearn.NewDefaultClient(*token)
 	for resp := range loop(time.Minute / time.Duration(*rpm), batches, client, *classifier) {
 		log.Printf("%#v\n", resp)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,7 +49,7 @@ func main() {
 	fmt.Printf("Remaining credits: %d / %d\n", client.RequestRemaining, client.RequestLimit)
 }
 
-func loop(rate time.Duration, batches []*monkeylearn.Batch, client *monkeylearn.Client, classifier string) (out chan monkeylearn.Result) {
+func loop(rate time.Duration, batches []monkeylearn.Batch, client *monkeylearn.Client, classifier string) (out chan monkeylearn.Result) {
 	out = make(chan monkeylearn.Result)
 
 	throttle := time.Tick(rate)
@@ -64,7 +64,7 @@ func loop(rate time.Duration, batches []*monkeylearn.Batch, client *monkeylearn.
 				out <- doc
 			}
 			wg.Done()
-		}(*batch)
+		}(batch)
 	}
 	go func() {
 		wg.Wait()

--- a/pkg/monkeylearn/batch.go
+++ b/pkg/monkeylearn/batch.go
@@ -37,7 +37,7 @@ func (b Batch) Classify(model string, client *Client) ([]Result, error) {
 	data, err := json.Marshal(b)
 	if err != nil { log.Panic(err) }
 
-	return client.Process(fmt.Sprintf(classifierURL, model), data)
+	return client.Process(client.server+fmt.Sprintf(classifierURL, model), data)
 }
 
 // Extract runs the extractor against the specified model
@@ -47,7 +47,7 @@ func (b Batch) Extract(model string, client *Client) ([]Result, error) {
 	data, err := json.Marshal(b)
 	if err != nil { log.Panic(err) }
 
-	return client.Process(fmt.Sprintf(extractorURL, model), data)
+	return client.Process(client.server+fmt.Sprintf(extractorURL, model), data)
 }
 
 // SplitInBatches takes a list of documents and the expected size of

--- a/pkg/monkeylearn/batch.go
+++ b/pkg/monkeylearn/batch.go
@@ -19,8 +19,8 @@ type Batch struct {
 }
 
 // NewBatch returns an empty Batch
-func NewBatch() *Batch {
-	return &Batch{}
+func NewBatch() Batch {
+	return Batch{}
 }
 
 // Add adds a set document to an existing Batch, updates the
@@ -53,11 +53,11 @@ func (b Batch) Extract(model string, client *Client) ([]Result, error) {
 // SplitInBatches takes a list of documents and the expected size of
 // each Batch and returns a list of Batches with batchSize elements
 // each.
-func SplitInBatches(docs []DataObject, batchSize int) []*Batch {
+func SplitInBatches(docs []DataObject, batchSize int) []Batch {
 	defer startTimer("Split in batches")()
-	batches := []*Batch{}
+	batches := []Batch{}
 	count := 0
-	var tmpbatch *Batch
+	var tmpbatch Batch
 	for _, doc := range docs {
 		if count % batchSize == 0 {
 			tmpbatch = NewBatch()

--- a/pkg/monkeylearn/batch_external_test.go
+++ b/pkg/monkeylearn/batch_external_test.go
@@ -1,0 +1,89 @@
+package monkeylearn_test
+
+import (
+	"testing"
+
+	"github.com/miguelbernadi/monkeylearn-go/pkg/monkeylearn"
+)
+
+func TestSplitInBatches(t *testing.T) {
+	docs :=  []monkeylearn.DataObject{
+		{
+			Text: "obladi",
+		},
+		{
+			Text: "oblada",
+		},
+	}
+	var table = []struct{
+		batchsize int
+		docs []monkeylearn.DataObject
+		result []monkeylearn.Batch
+	}{
+		{
+			batchsize: 1,
+			docs: docs,
+			result: []monkeylearn.Batch{
+				{
+					Data: []monkeylearn.DataObject{
+						{
+							Text: "obladi",
+						},
+					},
+				},
+				{
+					Data: []monkeylearn.DataObject{
+						{
+							Text: "oblada",
+						},
+					},
+				},
+			},
+		},
+		{
+			batchsize: 2,
+			docs: docs,
+			result: []monkeylearn.Batch{
+				{
+					Data: []monkeylearn.DataObject{
+						{
+							Text: "obladi",
+						},
+						{
+							Text: "oblada",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range table {
+		result := monkeylearn.SplitInBatches(tc.docs, tc.batchsize)
+		if len(result) != len(tc.result) {
+			t.Errorf(
+				"Mismatched number of batches,"+
+					" expected %d but got %d",
+				len(tc.result),
+				len(result),
+			)
+		}
+		for i, r := range result {
+			curData := tc.result[i].Data
+			
+			if len(r.Data) != len(curData) {
+				t.Errorf("Mismatched batch sizes,"+
+					"expected %d but got %d",
+					len(curData),
+					len(r.Data),
+				)
+			}
+			
+			for j, d := range r.Data {
+				if d != curData[j] {
+					t.Errorf("Mismatched batch contents")
+				}
+			}
+		}
+	}
+}

--- a/pkg/monkeylearn/client.go
+++ b/pkg/monkeylearn/client.go
@@ -12,27 +12,35 @@ import (
 )
 
 const (
-	classifierURL = "https://api.monkeylearn.com/v3/classifiers/%s/classify/"
-	extractorURL = "https://api.monkeylearn.com/v3/extractors/%s/extract/"
+	hostname = "https://api.monkeylearn.com"
+	classifierURL = "/v3/classifiers/%s/classify/"
+	extractorURL = "/v3/extractors/%s/extract/"
 )
 
 // Client holds the authentication data to connect to the MonkeyLearn
 // API and is used as gateway to operate with the API
 type Client struct {
-	http.Client
-	token string
+	client *http.Client
+	token, server string
 	RequestLimit, RequestRemaining int
 }
 
-// NewClient returns a new Client initialized with an authentication token
-func NewClient(token string) *Client {
-	return &Client{token: token}
+// NewClient returns a new Client initialized with a custom HTTP
+// client, and API token and a target hostname (e.g. proxying)
+func NewClient(client *http.Client, token, hostname string) *Client {
+	return &Client{client: client, token: token, server: hostname}
+}
+
+// NewDefaultClient returns a new Client initialized with an
+// authentication token usable for the official API
+func NewDefaultClient(token string) *Client {
+	return &Client{client: http.DefaultClient, token: token, server: hostname}
 }
 
 // Process does the appropriate call to the MonkeyLearn API and
 // handles the response
 func (c *Client) Process(endpoint string, data []byte) ([]Result, error) {
-	resp, err := c.Do(
+	resp, err := c.client.Do(
 		c.newRequest(endpoint, data),
 	)
 	if err != nil { log.Panic(err) }


### PR DESCRIPTION
**Allow client configuration of underlying settings**
This allows to set a custom HTTP client or transport layer, as needed,
and also to direct your requests towards a different server than the
official API (to provide a custom proxy, mocking, or any reason).

To keep the ease of use, introduce `NewDefaultClient` with the same
interface and default values to be a drop-in replacement of the
previous `NewClient` method.

**Better errors, less panics**
Avoid calling Panic in some non-critical situations (log an error
message instead) and improve the errors returned.

**Avoid unnecessary Batch pointers**
We only need to modify the batches in one occasion, otherwise prefer
to pass by value than reference.

**Add test for SplitInBatches**
This minimally tests the functionality of SplitInBatches function.