### PR TITLE
Avoid panicking on network error

### DIFF
--- a/pkg/monkeylearn/client.go
+++ b/pkg/monkeylearn/client.go
@@ -43,7 +43,7 @@ func (c *Client) Process(endpoint string, data []byte) ([]Result, error) {
 	resp, err := c.client.Do(
 		c.newRequest(endpoint, data),
 	)
-	if err != nil { log.Panic(err) }
+	if err != nil { return nil, err }
 
 	// We get rate limited. Do something
 	if resp.StatusCode == 429 {


### PR DESCRIPTION
While we decide what to do as of #6, at least avoid a Panic when one
of those situations happens. Bubble error up to the caller, so they
can handle it as they see fit.