### PR TITLE
Add fake server

### DIFF
--- a/cmd/fake/main.go
+++ b/cmd/fake/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var counts, errorRate, errors int
+var errorCodes []int
+
+func replyOK() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		message := strings.TrimPrefix("/", r.URL.Path)
+		message = message + " served ok"
+
+		responseCode := http.StatusOK
+		w.WriteHeader(responseCode)
+		w.Write([]byte(message))
+	})
+}
+
+func countRequests(next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		message := strings.TrimPrefix("/", r.URL.Path)
+		counts = counts + 1
+		// If errorRate is 0, no errors should be thrown;
+		// else, every errorRate requests will raise an error.
+		if errorRate > 0 && counts%errorRate == 0 {
+			errors = errors + 1
+			http.Error(
+				w,
+				"Errored request to "+message,
+				errorCodes[errors%len(errorCodes)],
+			)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func printCounts() {
+	for range time.Tick(10 * time.Second) {
+		fmt.Printf("requests=%v errors=%v\n", counts, errors)
+		counts = 0
+		errors = 0
+	}
+}
+
+func parseInts(ints *string) (intList []int) {
+	for _, n := range strings.Split(*ints, ",") {
+		value, err := strconv.Atoi(n)
+		if err != nil {
+			panic(err)
+		}
+		intList = append(intList, value)
+	}
+	return intList
+}
+
+func main() {
+	flag.IntVar(&errorRate, "errors", 0, "An error response will be sent every this number of requests.")
+	errorCodesList := flag.String("error-codes", "500", "comma-separated list of error codes to use when replying an error.")
+	flag.Parse()
+
+	errorCodes = parseInts(errorCodesList)
+	counts = 0
+	errors = 0
+
+	go printCounts()
+
+	http.HandleFunc("/", countRequests(replyOK()))
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
This adds a new command focused to provide a fake server to help testing client's code.
This fake server opens port 8080 and waits for requests, replying with proper requests.
Every 10 seconds, it prints how many requests and errors happened during the last
interval.

The fake server is capable to reply with a mixture of errors according to an error rate.
With the following invocation, the error rate would be 20%, i.e. one request of each 5
will be errored:

``` bash
fake-server --errors 20
```

It also accepts a comma-separated list of integers to use as HTTP response codes:

``` bash
fake-server --errors 100 --error-codes 403
fake-server --errors 34 --error-codes 500,502,503
```

The first command will always reply with 403, i.e. Unauthorized, while the second command
will reply aproximately a third of the requests with sequential repeatedly 500, 502, and 503 errors.